### PR TITLE
解説記事へのリンクを置く

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # OutgameSample
 アウトゲーム設計のサンプルプロジェクトです。
 
+プロジェクトの解説記事はこちらです。  
+https://tech.mirrativ.stream/entry/2023/09/22/112042
+
 ## 動作イメージ
 
 https://github.com/mr-imada/OutgameSample/assets/11347090/e15bc980-fda6-457f-a7b0-93d2f4d4a5bb


### PR DESCRIPTION
Githubのリポジトリからblogの解説記事へのリンクがあった方が双方向アクセスできて便利そう！！と思いました。

リポジトリのdescriptionに書くとかでも良さそうです。